### PR TITLE
Create folder that is a valid Windows folder name

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -379,10 +379,8 @@ class BackendCommand:
                           manager=self.archive_manager)
 
         try:
-            for item in items:
-                obj = json.dumps(item, indent=4, sort_keys=True)
-                self.outfile.write(obj)
-                self.outfile.write('\n')
+            obj = json.dumps(list(items), indent=4, sort_keys=True)
+            self.outfile.write(obj)
         except IOError as e:
             raise RuntimeError(str(e))
         except Exception as e:

--- a/perceval/backends/core/pipermail.py
+++ b/perceval/backends/core/pipermail.py
@@ -26,6 +26,7 @@
 import datetime
 import logging
 import os
+from urllib.parse import urlparse
 
 import bs4
 import dateutil
@@ -138,7 +139,7 @@ class PipermailCommand(BackendCommand):
 
         if not self.parsed_args.mboxes_path:
             base_path = os.path.expanduser('~/.perceval/mailinglists/')
-            dirpath = os.path.join(base_path, self.parsed_args.url)
+            dirpath = os.path.join(base_path, urlparse(self.parsed_args.url).netloc)
         else:
             dirpath = self.parsed_args.mboxes_path
 

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -540,7 +540,7 @@ class TestPipermailCommand(unittest.TestCase):
 
         cmd = PipermailCommand(*args)
         self.assertEqual(cmd.parsed_args.dirpath,
-                         os.path.join(self.tmp_path, 'testpath/http://example.com/'))
+                         os.path.join(self.tmp_path, 'testpath\\example.com'))
 
         args = ['http://example.com/',
                 '--mboxes-path', '/tmp/perceval/']


### PR DESCRIPTION
Previously this tried to create a folder using a full URL and would error because a full URL contains characters that Windows doesn't support for folder names.